### PR TITLE
Improve Claude Code repository guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,13 @@ python3 scripts/generate_readme.py
 
 # Bump marketplace/plugin manifest patch versions for changed plugins; used by CI
 python3 scripts/bump_versions.py <base-ref> <head-ref>
+
+# Optional: enable the repository pre-commit hook locally
+# The hook regenerates README.md and re-stages it when needed.
+git config core.hooksPath .githooks
 ```
 
-`.githooks/pre-commit` runs `python3 scripts/generate_readme.py` and re-stages `README.md` if the hook is configured locally. The GitHub workflow `.github/workflows/bump-versions.yml` runs `scripts/bump_versions.py` on pushes to `master` and commits manifest version updates.
+`.githooks/pre-commit` runs `python3 scripts/generate_readme.py` and re-stages `README.md` if the hook is configured locally. The GitHub workflow `.github/workflows/bump-versions.yml` runs `scripts/bump_versions.py` on pushes to `master` and commits manifest version updates for `.claude-plugin/marketplace.json` plus changed plugin manifests.
 
 ### Xiaohongshu automation engine
 
@@ -65,7 +69,7 @@ A typical plugin is organized around Claude Skills:
 - `scripts/` holds executable helpers used by the skill rather than content Claude should read eagerly.
 - `templates/` or resources are plugin-specific assets; for example social autopilot uses `templates/news_card.html`.
 
-The root `scripts/generate_readme.py` scans top-level `plugins/*/skills/*/SKILL.md` files, reads skill frontmatter, and rewrites the README section between `<!-- SKILLS:START -->` and `<!-- SKILLS:END -->`. It intentionally skips the embedded `xiaohongshu-skills/skills` submodule-like directory.
+The root `scripts/generate_readme.py` scans `plugins/*/skills/*/SKILL.md` and `plugins/*/*/skills/*/SKILL.md`, reads skill frontmatter, groups skills by plugin manifest description, and rewrites only the README section between `<!-- SKILLS:START -->` and `<!-- SKILLS:END -->`. It intentionally skips the embedded `xiaohongshu-skills/skills` submodule-like directory. Do not hand-edit the generated README catalog; update `SKILL.md` or plugin manifests and rerun the generator.
 
 ## Major plugin families
 
@@ -98,5 +102,7 @@ Use `skill-best-practices.md` and `CONTRIBUTING.md` when adding or revising skil
 
 - Skill names in frontmatter must be lowercase letters, numbers, and hyphens.
 - Descriptions should state both what the skill does and when it should trigger; they drive skill discovery and README generation.
+- Write frontmatter descriptions in third person and keep them specific enough for skill selection.
 - Keep `SKILL.md` concise and link one level down to `references/` for detailed procedures.
-- When adding a new plugin or skill, update the plugin manifest, root marketplace, and README catalog; prefer regenerating the README with `python3 scripts/generate_readme.py` rather than editing the generated section by hand.
+- Keep helper dependencies local to the skill directory (`requirements.txt`, local virtualenv setup, or plugin-local dispatcher); do not add a root package manager manifest just to support one plugin.
+- When adding a new plugin or skill, update the plugin manifest and root marketplace, then regenerate the README catalog with `python3 scripts/generate_readme.py` instead of editing the generated section by hand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ python3 scripts/bump_versions.py <base-ref> <head-ref>
 
 # Optional: enable the repository pre-commit hook locally
 # The hook regenerates README.md and re-stages it when needed.
+# Note: this overrides the default .git/hooks directory.
 git config core.hooksPath .githooks
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,19 +120,13 @@ Available categories:
 - `data-analysis` - Data analysis and processing tools
 - `security-systems` - Security and system tools
 
-### 2. Update README.md
+### 2. Regenerate README.md
 
-Add your skill to the appropriate category section in the main README.md:
+The main README skill catalog is generated from `SKILL.md` frontmatter and plugin manifests. Do not hand-edit the generated section; update the source skill or manifest metadata, then run:
 
-```markdown
-- [**Your Skill Name**](./your-skill-name/) - Brief description of what it does and key features.
+```bash
+python3 scripts/generate_readme.py
 ```
-
-Follow the existing format:
-- Use bold for skill names
-- Keep descriptions concise (1-2 sentences)
-- Link to the skill's directory
-- Add attribution if based on someone's work
 
 ## Pull Request Process
 
@@ -140,7 +134,7 @@ Follow the existing format:
 2. Create a branch: `git checkout -b add-skill-name`
 3. Add your skill folder with all required files
 4. Update `.claude-plugin/marketplace.json`
-5. Update `README.md` in the appropriate category
+5. Run `python3 scripts/generate_readme.py`
 6. Commit your changes: `git commit -m "Add [Skill Name] skill"`
 7. Push to your fork: `git push origin add-skill-name`
 8. Open a Pull Request
@@ -164,7 +158,7 @@ Explain the real-world use case and include:
 - [ ] SKILL.md with proper YAML frontmatter
 - [ ] README.md (optional but recommended)
 - [ ] marketplace.json updated
-- [ ] Main README.md updated
+- [ ] Main README.md regenerated with `python3 scripts/generate_readme.py`
 - [ ] Tested on at least one Claude platform
 - [ ] No duplicate functionality
 - [ ] Safe operations (confirms before destructive actions)


### PR DESCRIPTION
## Summary
- Add the optional command for enabling the repository pre-commit hook.
- Clarify how README skill catalog generation scans skill files and why the generated section should not be hand-edited.
- Expand skill authoring guidance with description and dependency-locality conventions.

## Test plan
- [x] Ran `python3 scripts/generate_readme.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)